### PR TITLE
fix fails on Gradle v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,10 +164,10 @@ If you wish to change location of report file, you should specify it in closure 
 inspectionsMain {
     reports {
         xml {
-            destination "reportFileName"
+            destination file("reportFileName")
         }
         html {
-            destination "reportFileName"
+            destination file("reportFileName")
         }
     }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    `kotlin-dsl`
+}
+
 buildscript {
     extra["kotlinVersion"] = "1.2.0"
     val kotlinVersion: String by extra
@@ -14,14 +18,10 @@ buildscript {
 
 val kotlinVersion: String by extra
 
-apply {
-    plugin("kotlin")
-}
-
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    compile("org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlinVersion")
+    compile("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion")
 }

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -5,7 +5,7 @@ import org.gradle.api.tasks.bundling.Jar
 import org.jetbrains.idea.inspections.*
 
 buildscript {
-    extra["kotlinVersion"] = "1.2.0"
+    extra["kotlinVersion"] = "1.3.72"
     extra["kotlinArgParserVersion"] = "2.0.7"
     val kotlinVersion: String by extra
 
@@ -27,14 +27,10 @@ val kotlinArgParserVersion: String by extra
 
 plugins {
     java
+    kotlin("jvm") version "1.3.72"
+    `maven-publish`
+    id("com.github.johnrengelman.shadow") version "2.0.1"
     id("com.jfrog.bintray") version "1.8.4"
-}
-
-apply {
-    plugin("kotlin")
-    plugin("maven-publish")
-    plugin("com.github.johnrengelman.shadow")
-    plugin("com.jfrog.bintray")
 }
 
 val projectName = "inspection-cli"

--- a/frontend/build.gradle.kts
+++ b/frontend/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
-    extra["kotlinVersion"] = "1.2.0"
+    extra["kotlinVersion"] = "1.3.72"
     val kotlinVersion: String by extra
 
     repositories {
@@ -17,10 +17,7 @@ val kotlinVersion: String by extra
 
 plugins {
     java
-}
-
-apply {
-    plugin("kotlin")
+    kotlin("jvm") version "1.3.72"
 }
 
 repositories {
@@ -28,6 +25,6 @@ repositories {
 }
 
 dependencies {
-    compileOnly("org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlinVersion")
+    compileOnly("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion")
     compile(project(":interface"))
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip

--- a/interface/build.gradle.kts
+++ b/interface/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
-    extra["kotlinVersion"] = "1.2.0"
+    extra["kotlinVersion"] = "1.3.72"
     val kotlinVersion: String by extra
 
     repositories {
@@ -17,10 +17,7 @@ val kotlinVersion: String by extra
 
 plugins {
     java
-}
-
-apply {
-    plugin("kotlin")
+    kotlin("jvm") version "1.3.72"
 }
 
 repositories {
@@ -28,6 +25,6 @@ repositories {
 }
 
 dependencies {
-    compileOnly("org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlinVersion")
+    compileOnly("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion")
     implementation("com.googlecode.json-simple:json-simple:1.1")
 }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.idea.inspections.*
 
 buildscript {
-    extra["kotlinVersion"] = "1.2.0"
+    extra["kotlinVersion"] = "1.3.72"
     val kotlinVersion: String by extra
 
     repositories {
@@ -22,14 +22,10 @@ val kotlinVersion: String by extra
 
 plugins {
     java
+    kotlin("jvm") version "1.3.72"
+    `java-gradle-plugin`
+    `maven-publish`
     id("com.jfrog.bintray") version "1.8.4"
-}
-
-apply {
-    plugin("java-gradle-plugin")
-    plugin("maven-publish")
-    plugin("com.jfrog.bintray")
-    plugin("kotlin")
 }
 
 val projectName = "inspection-plugin"
@@ -90,7 +86,7 @@ configurations {
 }
 
 dependencies {
-    compileOnly("org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlinVersion")
+    compileOnly("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion")
     compileOnly(gradleApi())
     compile("org.apache.httpcomponents:httpclient:4.5.5")
     compile("com.googlecode.json-simple:json-simple:1.1")

--- a/plugin/src/main/java/org/jetbrains/intellij/extensions/CodeQualityExtension.java
+++ b/plugin/src/main/java/org/jetbrains/intellij/extensions/CodeQualityExtension.java
@@ -1,6 +1,6 @@
 package org.jetbrains.intellij.extensions;
 
-import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.*;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -28,6 +28,8 @@ public class CodeQualityExtension {
         return ignoreFailures;
     }
 
+    @Input
+    @Optional
     public Boolean getIgnoreFailures() {
         return ignoreFailures;
     }
@@ -37,6 +39,7 @@ public class CodeQualityExtension {
     }
 
     @NotNull
+    @Internal
     public Collection<SourceSet> getSourceSets() {
         return sourceSets;
     }
@@ -45,6 +48,7 @@ public class CodeQualityExtension {
         this.sourceSets = sourceSets;
     }
 
+    @OutputDirectory
     public File getReportsDir() {
         return reportsDir;
     }

--- a/plugin/src/main/kotlin/org/jetbrains/intellij/IdeaCheckstyleReports.kt
+++ b/plugin/src/main/kotlin/org/jetbrains/intellij/IdeaCheckstyleReports.kt
@@ -1,7 +1,9 @@
 package org.jetbrains.intellij
 
 import org.gradle.api.Task
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.plugins.quality.CheckstyleReports
+import org.gradle.api.reporting.CustomizableHtmlReport
 import org.gradle.api.reporting.SingleFileReport
 import org.gradle.api.reporting.internal.CustomizableHtmlReportImpl
 import org.gradle.api.reporting.internal.TaskGeneratedSingleFileReport
@@ -9,14 +11,14 @@ import org.gradle.api.reporting.internal.TaskReportContainer
 
 class IdeaCheckstyleReports(
         task: Task
-) : TaskReportContainer<SingleFileReport>(SingleFileReport::class.java, task), CheckstyleReports {
+) : TaskReportContainer<SingleFileReport>(SingleFileReport::class.java, task, CollectionCallbackActionDecorator.NOOP), CheckstyleReports {
 
     init {
         add(CustomizableHtmlReportImpl::class.java, "html", task)
         add(TaskGeneratedSingleFileReport::class.java, "xml", task)
     }
 
-    override fun getHtml(): SingleFileReport = getByName("html")
+    override fun getHtml(): CustomizableHtmlReport = getByName("html") as CustomizableHtmlReport
 
     override fun getXml(): SingleFileReport = getByName("xml")
 }

--- a/plugin/src/main/kotlin/org/jetbrains/intellij/extensions/IdeaExtension.kt
+++ b/plugin/src/main/kotlin/org/jetbrains/intellij/extensions/IdeaExtension.kt
@@ -1,11 +1,16 @@
 package org.jetbrains.intellij.extensions
 
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+
 class IdeaExtension {
 
     /**
      * Version of IDEA
      */
     @Suppress("unused")
+    @Input
+    @Optional
     var version: String? = null
 
     /**

--- a/plugin/src/main/kotlin/org/jetbrains/intellij/extensions/InspectionPluginExtension.kt
+++ b/plugin/src/main/kotlin/org/jetbrains/intellij/extensions/InspectionPluginExtension.kt
@@ -2,6 +2,9 @@ package org.jetbrains.intellij.extensions
 
 import org.gradle.api.Action
 import org.gradle.api.Project
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.Optional
 
 open class InspectionPluginExtension(
         @Suppress("unused") private val project: Project?
@@ -10,58 +13,72 @@ open class InspectionPluginExtension(
     /**
      * Configuration of IDEA.
      */
+    @Nested
     var idea = IdeaExtension()
 
     /**
      * Whether rule violations are to be displayed on the console.
      */
+    @get:Input
+    @get:Optional
     var isQuiet: Boolean? = null
 
     /**
      * Whether temp directory (with all caches) is located in home.
      * By default, it's located in temp
      */
+    @get:Input
+    @get:Optional
     var isTempDirInHome: Boolean? = null
 
     /**
      * If this value is <tt>true</tt> implementation of inspections will be found in IDEA
      * profile with given {@profileName}.
      */
+    @Optional
+    @Input
     var inheritFromIdea: Boolean? = null
 
     /**
      * Name of profiles in IDEA. Needed for finding implementation of inspections.
      */
+    @Input
+    @Optional
     var profileName: String? = null
 
     /**
      * Error inspections configurations.
      * @see InspectionsExtension
      */
+    @Nested
     val errors = InspectionsExtension()
 
     /**
      * Warning inspections configurations.
      * @see InspectionsExtension
      */
+    @Nested
     val warnings = InspectionsExtension()
 
     /**
      * Info inspections configurations.
      * @see InspectionsExtension
      */
+    @Nested
     val info = InspectionsExtension()
 
     /**
      * Reformat task configurations.
      * @see ReformatExtension
      */
+    @Nested
     val reformat = ReformatExtension()
 
     /**
      * Configurations of IDEA plugins.
      * @see PluginsExtension
      */
+    @Nested
     val plugins = PluginsExtension()
 
     /**
@@ -69,6 +86,8 @@ open class InspectionPluginExtension(
      */
     @Suppress("unused")
     @Deprecated("To be replaced with errors.max = n", ReplaceWith("errors.max"))
+    @get:Input
+    @get:Optional
     var maxErrors: Int?
         get() = errors.max
         set(value) {
@@ -80,6 +99,8 @@ open class InspectionPluginExtension(
      */
     @Suppress("unused")
     @Deprecated("To be replaced with warnings.max = n", ReplaceWith("warnings.max"))
+    @get:Input
+    @get:Optional
     var maxWarnings: Int?
         get() = warnings.max
         set(value) {
@@ -93,6 +114,8 @@ open class InspectionPluginExtension(
      */
     @Suppress("unused")
     @Deprecated("To be replaced with idea.version = n", ReplaceWith("idea.version"))
+    @get:Input
+    @get:Optional
     var toolVersion: String?
         get() = idea.version
         set(value) {

--- a/plugin/src/main/kotlin/org/jetbrains/intellij/extensions/InspectionsExtension.kt
+++ b/plugin/src/main/kotlin/org/jetbrains/intellij/extensions/InspectionsExtension.kt
@@ -1,5 +1,8 @@
 package org.jetbrains.intellij.extensions
 
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
 import java.util.*
 
 class InspectionsExtension {
@@ -9,11 +12,14 @@ class InspectionsExtension {
      * or setting the failure property. <tt>null</tt> value means that that there are no limits on the
      * number of problems.
      */
+    @Input
+    @Optional
     var max: Int? = null
 
     /**
      * Registered inspections settings
      */
+    @Internal
     val inspections: Map<String, InspectionExtension> = HashMap()
 
     /**

--- a/plugin/src/main/kotlin/org/jetbrains/intellij/extensions/PluginExtension.kt
+++ b/plugin/src/main/kotlin/org/jetbrains/intellij/extensions/PluginExtension.kt
@@ -1,15 +1,22 @@
 package org.jetbrains.intellij.extensions
 
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+
 class PluginExtension {
 
     /**
      * Version of plugin
      */
+    @get:Input
+    @get:Optional
     var version: String? = null
 
     /**
      * Location of plugin
      */
+    @get:Input
+    @get:Optional
     var location: String? = null
 
     /**

--- a/plugin/src/main/kotlin/org/jetbrains/intellij/extensions/PluginsExtension.kt
+++ b/plugin/src/main/kotlin/org/jetbrains/intellij/extensions/PluginsExtension.kt
@@ -1,12 +1,14 @@
 package org.jetbrains.intellij.extensions
 
 import org.gradle.api.Action
+import org.gradle.api.tasks.Nested
 
 class PluginsExtension {
 
     /**
      * Configurations of kotlin plugin.
      */
+    @Nested
     val kotlin = PluginExtension()
 
     @Suppress("unused")

--- a/plugin/src/main/kotlin/org/jetbrains/intellij/extensions/ReformatExtension.kt
+++ b/plugin/src/main/kotlin/org/jetbrains/intellij/extensions/ReformatExtension.kt
@@ -1,10 +1,15 @@
 package org.jetbrains.intellij.extensions
 
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+
 class ReformatExtension {
 
     /**
      * Quick fix are to be executed if found fixable code style errors.
      */
+    @get:Input
+    @get:Optional
     var quickFix: Boolean? = null
 
     /**

--- a/plugin/src/main/kotlin/org/jetbrains/intellij/tasks/AbstractInspectionsTask.kt
+++ b/plugin/src/main/kotlin/org/jetbrains/intellij/tasks/AbstractInspectionsTask.kt
@@ -87,6 +87,7 @@ abstract class AbstractInspectionsTask : SourceTask(), VerificationTask {
      *
      * @return false if temp directory is located in java.io.tmpdir (default), true if it's located in user.home
      */
+    @get:Input
     open val isTempDirInHome: Boolean
         get() = extension.isTempDirInHome()
 
@@ -169,18 +170,16 @@ abstract class AbstractInspectionsTask : SourceTask(), VerificationTask {
     open val maxInfo: Int?
         get() = extension.info.max
 
-    @get:Internal
     private val inspections: Map<String, InspectionsRunnerParameters.Inspection>
         get() = errorsInspections + warningsInspections + infoInspections
 
     @Internal
     private var ignoreFailures: Boolean? = null
 
-    @get:Internal
+    @get:Nested
     protected val extension: InspectionPluginExtension
         get() = project.extensions.findByType(InspectionPluginExtension::class.java)!!
 
-    @Internal
     private fun getInspections(ex: InspectionsExtension): Map<String, InspectionsRunnerParameters.Inspection> {
         val inspections = ex.inspections.map {
             val quickFix = it.value.quickFix ?: false
@@ -197,7 +196,6 @@ abstract class AbstractInspectionsTask : SourceTask(), VerificationTask {
     @get:Optional
     open val html: File? = null
 
-    @Internal
     private fun getIdeaRunnerParameters(): IdeaRunnerParameters<FileInfoRunnerParameters<InspectionsRunnerParameters>> {
         val ideaDirectory = ideaDirectory(ideaVersion, isTempDirInHome)
         val ideaSystemDirectory = ideaSystemDirectory(ideaVersion)
@@ -215,7 +213,6 @@ abstract class AbstractInspectionsTask : SourceTask(), VerificationTask {
         )
     }
 
-    @Internal
     private fun getFileInfoParameters(): FileInfoRunnerParameters<InspectionsRunnerParameters> {
         return FileInfoRunnerParameters(
                 files = getSource().files.toList(),
@@ -223,7 +220,6 @@ abstract class AbstractInspectionsTask : SourceTask(), VerificationTask {
         )
     }
 
-    @Internal
     private fun getInspectionsRunnerParameters(): InspectionsRunnerParameters {
         val reportParameters = InspectionsRunnerParameters.Report(isQuiet, xml, html)
         val errors = InspectionsRunnerParameters.Inspections(errorsInspections, maxErrors)
@@ -325,15 +321,16 @@ abstract class AbstractInspectionsTask : SourceTask(), VerificationTask {
     }
 
     inner class IdeaFinishingListener : BuildListener {
-        override fun buildFinished(result: BuildResult?) = Runner.finalize(logger)
 
-        override fun projectsLoaded(gradle: Gradle?) {}
+        override fun buildFinished(result: BuildResult) = Runner.finalize(logger)
 
-        override fun buildStarted(gradle: Gradle?) {}
+        override fun projectsLoaded(gradle: Gradle) {}
 
-        override fun projectsEvaluated(gradle: Gradle?) {}
+        override fun buildStarted(gradle: Gradle) {}
 
-        override fun settingsEvaluated(settings: Settings?) {}
+        override fun projectsEvaluated(gradle: Gradle) {}
+
+        override fun settingsEvaluated(settings: Settings) {}
     }
 
     init {

--- a/plugin/src/main/kotlin/org/jetbrains/intellij/tasks/DownloadKotlinPluginTask.kt
+++ b/plugin/src/main/kotlin/org/jetbrains/intellij/tasks/DownloadKotlinPluginTask.kt
@@ -47,7 +47,6 @@ open class DownloadKotlinPluginTask : ConventionTask() {
         Downloader(logger).download(location, isTempDirInHome, archiveDirectory!!)
     }
 
-    @get:Internal
     private val extension: InspectionPluginExtension
         get() = project.extensions.findByType(InspectionPluginExtension::class.java)!!
 }

--- a/plugin/src/main/kotlin/org/jetbrains/intellij/tasks/InspectionsTask.kt
+++ b/plugin/src/main/kotlin/org/jetbrains/intellij/tasks/InspectionsTask.kt
@@ -3,10 +3,10 @@ package org.jetbrains.intellij.tasks
 import groovy.lang.Closure
 import groovy.lang.DelegatesTo
 import org.gradle.api.Action
-import org.gradle.api.internal.ClosureBackedAction
 import org.gradle.api.plugins.quality.CheckstyleReports
 import org.gradle.api.reporting.Reporting
 import org.gradle.api.tasks.*
+import org.gradle.util.ClosureBackedAction
 import org.jetbrains.intellij.IdeaCheckstyleReports
 import java.io.File
 import org.gradle.api.Project as GradleProject
@@ -32,10 +32,10 @@ open class InspectionsTask : AbstractInspectionsTask(), Reporting<CheckstyleRepo
      * inspection {
      *     reports {
      *         html {
-     *             destination "build/codenarc.html"
+     *             destination file("build/codenarc.html")
      *         }
      *         xml {
-     *             destination "build/report.xml"
+     *             destination file("build/report.xml")
      *         }
      *     }
      * }
@@ -58,7 +58,7 @@ open class InspectionsTask : AbstractInspectionsTask(), Reporting<CheckstyleRepo
      * checkstyleTask {
      *     reports {
      *         html {
-     *             destination "build/codenarc.html"
+     *             destination file("build/codenarc.html")
      *         }
      *     }
      * }

--- a/plugin/src/main/kotlin/org/jetbrains/intellij/tasks/ReformatTask.kt
+++ b/plugin/src/main/kotlin/org/jetbrains/intellij/tasks/ReformatTask.kt
@@ -31,11 +31,9 @@ open class ReformatTask : AbstractInspectionsTask() {
     override val profileName: String?
         get() = null
 
-    @get:Internal
     private val reformatQuickFix: Boolean
         get() = extension.reformat.quickFix ?: true
 
-    @get:Internal
     private val reformatInspectionToolParameters: InspectionsRunnerParameters.Inspection
         get() = InspectionsRunnerParameters.Inspection("Reformat", reformatQuickFix)
 }

--- a/plugin/src/main/kotlin/org/jetbrains/intellij/tasks/UnzipIdeaTask.kt
+++ b/plugin/src/main/kotlin/org/jetbrains/intellij/tasks/UnzipIdeaTask.kt
@@ -52,7 +52,6 @@ open class UnzipIdeaTask : ConventionTask() {
         }
     }
 
-    @get:Internal
     private val extension: InspectionPluginExtension
         get() = project.extensions.findByType(InspectionPluginExtension::class.java)!!
 }

--- a/plugin/src/main/kotlin/org/jetbrains/intellij/tasks/UnzipKotlinPluginTask.kt
+++ b/plugin/src/main/kotlin/org/jetbrains/intellij/tasks/UnzipKotlinPluginTask.kt
@@ -46,7 +46,7 @@ open class UnzipKotlinPluginTask : ConventionTask() {
             logger.info("InspectionPlugin: Using kotlin plugin inherit from idea.")
             return
         }
-        UpToDateChecker(HashUtil.sha256(archive).asHexString(), isTempDirInHome).apply {
+        UpToDateChecker(HashUtil.sha256(archive!!).asHexString(), isTempDirInHome).apply {
             onUpToDate {
                 logger.info("InspectionPlugin: No unzipping needed.")
             }
@@ -59,7 +59,6 @@ open class UnzipKotlinPluginTask : ConventionTask() {
         }
     }
 
-    @get:Internal
     private val extension: InspectionPluginExtension
         get() = project.extensions.findByType(InspectionPluginExtension::class.java)!!
 }

--- a/runner/build.gradle.kts
+++ b/runner/build.gradle.kts
@@ -6,7 +6,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.idea.inspections.*
 
 buildscript {
-    extra["kotlinVersion"] = "1.2.0"
+    extra["kotlinVersion"] = "1.3.72"
     val kotlinVersion: String by extra
 
     repositories {
@@ -26,14 +26,10 @@ val kotlinVersion: String by extra
 
 plugins {
     java
+    kotlin("jvm") version "1.3.72"
+    `maven-publish`
     id("com.jfrog.bintray") version "1.8.4"
-}
-
-apply {
-    plugin("kotlin")
-    plugin("maven-publish")
-    plugin("com.github.johnrengelman.shadow")
-    plugin("com.jfrog.bintray")
+    id("com.github.johnrengelman.shadow") version "2.0.1"
 }
 
 val projectName = "inspection-runner"

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,7 +2,7 @@ group 'org.jetbrains'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.2.60'
+    ext.kotlin_version = '1.3.72'
 
     repositories {
         mavenLocal()

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,12 +3,7 @@ include 'interface'
 include 'runner'
 include 'plugin'
 include 'cli'
-include 'sample'
+// FixMe: sample module is depending v0.3.2, always failed gradle sync on Gradle v6. Please remove comment out when this PR merged
+// include 'sample'
 include 'frontend'
 include 'testing'
-
-// It flag provided stable plugin publishing (configuration of publishing
-// task will be in-place but not a in end of build configuration). It needed
-// for supporting gradle with version 5.0.
-enableFeaturePreview("STABLE_PUBLISHING")
-

--- a/testing/build.gradle.kts
+++ b/testing/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
-    extra["kotlinVersion"] = "1.2.0"
+    extra["kotlinVersion"] = "1.3.72"
     val kotlinVersion: String by extra
 
     repositories {
@@ -18,11 +18,8 @@ val kotlinVersion: String by extra
 
 plugins {
     java
-}
-
-apply {
-    plugin("kotlin")
-    plugin("java-gradle-plugin")
+    kotlin("jvm") version "1.3.72"
+    `java-gradle-plugin`
 }
 
 repositories {

--- a/testing/src/test/kotlin/org/jetbrains/intellij/TestBench.kt
+++ b/testing/src/test/kotlin/org/jetbrains/intellij/TestBench.kt
@@ -53,7 +53,7 @@ abstract class TestBench<in T> {
         }.flatten()
         val xmlReport = lines.getParameterValue("xmlReport", "false").toBoolean()
         val htmlReport = lines.getParameterValue("htmlReport", "false").toBoolean()
-        val kotlinVersion = lines.getParameterValue("kotlinVersion", "1.2.0")
+        val kotlinVersion = lines.getParameterValue("kotlinVersion", "1.3.72")
         val expectedDiagnosticsStatus = lines.asSequence()
                 .map { it.trim() }
                 .find { it == "// SHOULD_BE_ABSENT" }

--- a/testing/src/test/kotlin/org/jetbrains/intellij/plugin/PluginTestBench.kt
+++ b/testing/src/test/kotlin/org/jetbrains/intellij/plugin/PluginTestBench.kt
@@ -99,16 +99,13 @@ class PluginTestBench(private val taskName: String) : TestBench<InspectionPlugin
                             appendln("    plugins.kotlin.location $it")
                         }
                         "xmlDestination" -> if (xmlReport) {
-                            appendln("            destination \"build/report.xml\"")
+                            appendln("            destination file(\"build/report.xml\")")
                         }
                         "htmlDestination" -> if (htmlReport) {
-                            appendln("            destination \"build/report.html\"")
+                            appendln("            destination file(\"build/report.html\")")
                         }
                         "kotlin-stdlib" -> if (kotlinNeeded) {
                             appendln("    compile \"org.jetbrains.kotlin:kotlin-stdlib\"")
-                        }
-                        "kotlin-runtime" -> if (kotlinNeeded) {
-                            appendln("    compile \"org.jetbrains.kotlin:kotlin-runtime\"")
                         }
                         "compile-kotlin" -> if (kotlinNeeded) {
                             appendln("""

--- a/testing/testData/build.gradle.template
+++ b/testing/testData/build.gradle.template
@@ -55,7 +55,6 @@ repositories {
 }
 dependencies {
     <kotlin-stdlib>
-    <kotlin-runtime>
 }
 <compile-kotlin>
 


### PR DESCRIPTION
## Summary
- fix #20, fix #28 
- update gradle to 6.0.1 from 4.9
- and fix some issue
  - update kotlin because 1.2.0 is failed on Gradle v6
  - change `kotlin-stdlib-jre8` to `kotlin-stdlib-jdk8`
  - remove `kotlin-runtime` on test code because integrated to `kotlin-stdlib`
  - add or remove some annotation
  - fix `IdeaCheckstyleReports`
  - etc..

## Additional
I think `testStdlib` test case seems to fail regardless of this PR